### PR TITLE
change the socket from x11 to fallback-x11

### DIFF
--- a/org.kde.gcompris.json
+++ b/org.kde.gcompris.json
@@ -8,7 +8,7 @@
   "finish-args": [
     "--socket=pulseaudio",
     "--share=ipc",
-    "--socket=x11",
+    "--socket=fallback-x11",
     "--socket=wayland",
     "--share=network",
     "--device=dri"


### PR DESCRIPTION
Flathub marks GCompris as potential unsafe due to legacy windowing system (https://flathub.org/apps/org.kde.gcompris) According to https://github.com/flathub/org.plomgrading.PlomClient/issues/32, changing the socket from x11 to fallback-x11 should fix the error.

Note I haven't tried the change as I'm not using flatpak, I don't know if it has any side effect. In doubt, don't merge it.