### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.gcompris.json
+++ b/org.kde.gcompris.json
@@ -13,6 +13,10 @@
         "--share=network",
         "--device=dri"
     ],
+     "cleanup": [
+        "/include",
+        "/mkspecs"
+    ],
     "modules": [
         {
             "name": "qt6-graphs",


### PR DESCRIPTION
The installed size reduced from 102.1 MB to 101.6 MB.

Remove development-related files to reduce Flatpak size.

Not impressive. 